### PR TITLE
Correct image URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,6 @@ This plugin is licensed under the [MIT License][mit_license_url].
 
 [mit_license_url]: https://github.com/makjac/flutter_file_info/blob/main/LICENSE
 
-[header_image_url]: https://i.imgur.com/5uioqZd.png
-[windows_example_url]: https://i.imgur.com/Yo0GhFM.gif
-[android_example_url]: https://i.imgur.com/EKQ3WDK.gif
+[header_image_url]: https://raw.githubusercontent.com/makjac/images/refs/heads/main/flutter_file_info/flutter_file_info_banner.png
+[windows_example_url]: https://raw.githubusercontent.com/makjac/images/refs/heads/main/flutter_file_info/file_info_win.gif
+[android_example_url]: https://raw.githubusercontent.com/makjac/images/refs/heads/main/flutter_file_info/flutter_file_info_android.gif


### PR DESCRIPTION
This pull request includes updates to the image URLs in the `README.md` file to use the raw content from the repository instead of Imgur links.

Changes to image URLs:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R96): Updated `header_image_url`, `windows_example_url`, and `android_example_url` to use raw content URLs from the repository.